### PR TITLE
[PR Sandbox] Jacoco 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("jvm") version "1.6.10"
     kotlin("plugin.spring") version "1.6.10"
     kotlin("plugin.jpa") version "1.6.10"
+    jacoco
 }
 
 group = "com.example"
@@ -36,6 +37,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+    testImplementation("org.jacoco:org.jacoco.agent:0.8.7")
 }
 
 tasks.withType<KotlinCompile> {
@@ -47,4 +49,37 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+kotlin.sourceSets.main {
+    setBuildDir("${buildDir}/generated/source/kapt/main")
+}
+
+// - jacoco : 사용 방법 ./gradlew --console verbose test jacocoTestReport jacocoTestCoverageVerification
+jacoco {
+    // Jacoco Version
+    toolVersion = "0.8.7"
+}
+
+tasks {
+    jacocoTestReport {
+        reports {
+            // 원하는 리포트를 켜고 끌 수 있습니다.
+            html.required.set(true)
+            xml.required.set(false)
+            csv.required.set(false)
+        }
+    }
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule {
+                element = "CLASS"
+                limit {
+                    counter = "BRANCH"
+                    value = "COVEREDRATIO"
+                    minimum = "0.80".toBigDecimal()
+                }
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/example/be/entity/Board.kt
+++ b/src/main/kotlin/com/example/be/entity/Board.kt
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.core.mapping.Field
 import java.time.LocalDateTime
 import java.util.Collections
 
-@Document(collection = "auto_sequence")
+@Document()
 data class Board (
     @Id
     val id: String?,

--- a/src/main/kotlin/com/example/be/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/be/handler/GlobalExceptionHandler.kt
@@ -18,7 +18,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
-        return ResponseEntity(ErrorResponse(e.message ?: e.toString()), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(ErrorResponse(e.toString()), HttpStatus.BAD_REQUEST)
     }
 
 }

--- a/src/test/kotlin/com/example/be/Fixture.kt
+++ b/src/test/kotlin/com/example/be/Fixture.kt
@@ -64,6 +64,18 @@ class Fixture {
             comments = Collections.singletonList(comment)
         )
 
+        val boardWithoutComment = Board(
+            id = "test",
+            userEmail = "testEmail",
+            nickName = "test",
+            subTitle = "testTitle",
+            titleImage = "testImage",
+            likes = 0,
+            modDateTime = LocalDateTime.now(),
+            contents = Collections.singletonList(content),
+            comments = null
+        )
+
         val insertBoardDto = InsertBoardDto(
             userEmail = "testEmail",
             nickName = "test",

--- a/src/test/kotlin/com/example/be/service/BoardServiceImplTest.kt
+++ b/src/test/kotlin/com/example/be/service/BoardServiceImplTest.kt
@@ -53,8 +53,24 @@ internal class BoardServiceImplTest {
         }
 
         @Test
-        @DisplayName("DB에 userEmail에 대응되는 board가 없다면, content가 empty인 Page를 반환한다.")
+        @DisplayName("DB에 userEmail에 대응되는 board에서 comments가 null인 경우 board의 comments는 empty Collection로 반환한다.")
         fun test01() {
+            // given
+            val pageRequest = PageRequest.of(0, 10)
+            val userEmail = Fixture.boardDto.userEmail
+            val list: PageImpl<Board> = PageImpl(listOf(Fixture.boardWithoutComment))
+
+            // when
+            Mockito.`when`(repository.findAllByUserEmail(any(), Mockito.anyString())).thenReturn(list)
+
+            // then
+            val boardDtoPage: Page<BoardDto> = service.getAllBoard(pageRequest, userEmail)
+            assertTrue(boardDtoPage.content[0].comments.isEmpty())
+        }
+
+        @Test
+        @DisplayName("DB에 userEmail에 대응되는 board가 없다면, content가 empty인 Page를 반환한다.")
+        fun test02() {
             // given
             val pageRequest = PageRequest.of(0, 10)
             val userEmail = "Error"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  data:
+    mongodb:
+      database: test
+      uri: mongodb://admin:test123@onegodev.ddns.net:2727/test?authSource=test&readPreference=primary&directConnection=true&ssl=false
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    generate-ddl: true
+
+logging:
+  level:
+    org.springframework.data.mongodb.core.MongoTemplate: DEBUG


### PR DESCRIPTION
- Jacoco 적용
- 실행방법 : ./gradlew --console verbose test jacocoTestReport jacocoTestCoverageVerification

![스크린샷 2022-04-26 오후 3 29 30](https://user-images.githubusercontent.com/46814964/165235980-8032f43e-48e3-4d37-b2d8-71fc2d935a33.png)

- 위와 같이 명령어에 따라서 터미널에서도 테스트 coverage의 실패 여부와 얼마나 coverage를 달성했는지도 볼 수 있습니다.
- build.grade.kts에 설정한 kotlin.sourceSets.main 부분을 보면 알 수 있듯이

![스크린샷 2022-04-26 오후 3 31 45](https://user-images.githubusercontent.com/46814964/165236318-8a24abd8-fda5-4e1f-aa38-b16b3969c6d0.png)

위와 같이 설정한 디렉토리로 접근을 하면 

![스크린샷 2022-04-26 오후 3 32 20](https://user-images.githubusercontent.com/46814964/165236396-4eb7c8a6-43dc-4ad2-a68f-8c95654ef727.png)
index.html파일을 발견할수있고 해당 파일을 열어서 시각화된 결과를 확인 할 수 있습니다. (어떤 파일을 생성하는지도 설정에서 설정 가능합니다.)

<img width="1044" alt="스크린샷 2022-04-26 오후 3 33 08" src="https://user-images.githubusercontent.com/46814964/165236520-fe5929d2-e712-47df-b0d8-abe1d4e27834.png">


+++ 추가 작업
- BoardRepositoryTest를 수행하기 위해 Test용 DB 설정 (test/resources/application.yml)
- BoardRepositoryTest 수정 완료
- Board Entity 에서 Document Annotation에서 collation 설정이 mongoDB 버전과 호환되지 않아 삭제