### PR TITLE
[PR Sandbox] Login 관련 Controller & Service 수정

### DIFF
--- a/src/main/kotlin/com/example/be/controller/UserController.kt
+++ b/src/main/kotlin/com/example/be/controller/UserController.kt
@@ -56,10 +56,7 @@ class UserController (val userService: UserService){
 
     @DeleteMapping
     fun deleteUser(@RequestBody userRegisterDto: UserRegisterDto): ResponseEntity<Boolean> {
-        return if (userService.deleteUser(userRegisterDto)) {
-            ResponseEntity(true, HttpStatus.OK)
-        } else {
-            ResponseEntity(false, HttpStatus.INTERNAL_SERVER_ERROR)
-        }
+        userService.deleteUser(userRegisterDto)
+        return ResponseEntity(true, HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/example/be/controller/UserController.kt
+++ b/src/main/kotlin/com/example/be/controller/UserController.kt
@@ -55,8 +55,8 @@ class UserController (val userService: UserService){
     }
 
     @DeleteMapping
-    fun deleteUser(@RequestParam userId: String): ResponseEntity<Boolean> {
-        return if (userService.deleteUser(userId)) {
+    fun deleteUser(@RequestBody userRegisterDto: UserRegisterDto): ResponseEntity<Boolean> {
+        return if (userService.deleteUser(userRegisterDto)) {
             ResponseEntity(true, HttpStatus.OK)
         } else {
             ResponseEntity(false, HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/kotlin/com/example/be/controller/UserController.kt
+++ b/src/main/kotlin/com/example/be/controller/UserController.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -27,8 +28,8 @@ class UserController (val userService: UserService){
     }
 
     @GetMapping("/login")
-    fun login(@RequestParam userId: String, @RequestParam password: String): ResponseEntity<Boolean> {
-        return if (userService.login(userId, password)) {
+    fun login(@ModelAttribute userRegisterDto: UserRegisterDto): ResponseEntity<Boolean> {
+        return if (userService.login(userRegisterDto)) {
             ResponseEntity(true, HttpStatus.OK)
         } else {
             ResponseEntity(false, HttpStatus.NOT_FOUND)
@@ -46,7 +47,7 @@ class UserController (val userService: UserService){
 
     @PutMapping
     fun updateUserProfile(@RequestBody updateUserDto: UpdateUserDto): ResponseEntity<Boolean> {
-        return if (userService.changePassword(updateUserDto)) {
+        return if (userService.updateUserProfile(updateUserDto)) {
             ResponseEntity(true, HttpStatus.OK)
         } else {
             ResponseEntity(false, HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/kotlin/com/example/be/controller/UserController.kt
+++ b/src/main/kotlin/com/example/be/controller/UserController.kt
@@ -46,7 +46,7 @@ class UserController (val userService: UserService){
 
     @PutMapping
     fun updateUserProfile(@RequestBody updateUserDto: UpdateUserDto): ResponseEntity<Boolean> {
-        return if (userService.updateUserProfile(updateUserDto)) {
+        return if (userService.changePassword(updateUserDto)) {
             ResponseEntity(true, HttpStatus.OK)
         } else {
             ResponseEntity(false, HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/kotlin/com/example/be/exception/NoneBoardException.kt
+++ b/src/main/kotlin/com/example/be/exception/NoneBoardException.kt
@@ -1,4 +1,7 @@
 package com.example.be.exception
 
+import com.example.be.dto.UserRegisterDto
+
 data class NoneBoardException(val msg: String): RuntimeException(msg)
 data class NoneUserException(val msg: String): RuntimeException(msg)
+data class NotValidUserRegisterFormException(val msg: String, val userRegisterDto: UserRegisterDto): RuntimeException(msg)

--- a/src/main/kotlin/com/example/be/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/be/handler/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.example.be.handler
 import com.example.be.dto.ErrorResponse
 import com.example.be.exception.NoneBoardException
 import com.example.be.exception.NoneUserException
+import com.example.be.exception.NotValidUserRegisterFormException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -27,4 +28,8 @@ class GlobalExceptionHandler {
         return ResponseEntity(ErrorResponse(msg = e.msg), HttpStatus.NOT_FOUND)
     }
 
+    @ExceptionHandler(NotValidUserRegisterFormException::class)
+    fun handleNotValidUserRegisterFormException(e: NotValidUserRegisterFormException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity(ErrorResponse(msg = e.msg), HttpStatus.BAD_REQUEST)
+    }
 }

--- a/src/main/kotlin/com/example/be/repository/UserRepository.kt
+++ b/src/main/kotlin/com/example/be/repository/UserRepository.kt
@@ -4,4 +4,6 @@ import com.example.be.entity.User
 import org.springframework.data.mongodb.repository.MongoRepository
 
 interface UserRepository: MongoRepository<User, String> {
+    fun deleteUserByEmail(userEmail: String)
+    fun findByEmail(userEmail: String): User?
 }

--- a/src/main/kotlin/com/example/be/service/UserService.kt
+++ b/src/main/kotlin/com/example/be/service/UserService.kt
@@ -8,6 +8,7 @@ interface UserService {
     fun getUserProfile(userId: String): UserDto
     fun register(userRegisterDto: UserRegisterDto): Boolean
     fun login(userId: String, password: String): Boolean
-    fun updateUserProfile(updateUserDto: UpdateUserDto): Boolean
+    fun changePassword(updateUserDto: UpdateUserDto): Boolean
     fun deleteUser(userId: String): Boolean
+    fun checkDuplicateId(userId: String): Boolean
 }

--- a/src/main/kotlin/com/example/be/service/UserService.kt
+++ b/src/main/kotlin/com/example/be/service/UserService.kt
@@ -10,6 +10,6 @@ interface UserService {
     fun login(userRegisterDto: UserRegisterDto): Boolean
     fun changePassword(userRegisterDto: UserRegisterDto): Boolean
     fun updateUserProfile(updateUserDto: UpdateUserDto): Boolean
-    fun deleteUser(userId: String): Boolean
-    fun checkDuplicateId(userId: String): Boolean
+    fun deleteUser(userEmail: String): Boolean
+    fun checkDuplicateId(userEmail: String): Boolean
 }

--- a/src/main/kotlin/com/example/be/service/UserService.kt
+++ b/src/main/kotlin/com/example/be/service/UserService.kt
@@ -10,6 +10,6 @@ interface UserService {
     fun login(userRegisterDto: UserRegisterDto): Boolean
     fun changePassword(userRegisterDto: UserRegisterDto): Boolean
     fun updateUserProfile(updateUserDto: UpdateUserDto): Boolean
-    fun deleteUser(userEmail: String): Boolean
+    fun deleteUser(userRegisterDto: UserRegisterDto): Boolean
     fun checkDuplicateId(userEmail: String): Boolean
 }

--- a/src/main/kotlin/com/example/be/service/UserService.kt
+++ b/src/main/kotlin/com/example/be/service/UserService.kt
@@ -7,8 +7,9 @@ import com.example.be.dto.UserRegisterDto
 interface UserService {
     fun getUserProfile(userId: String): UserDto
     fun register(userRegisterDto: UserRegisterDto): Boolean
-    fun login(userId: String, password: String): Boolean
-    fun changePassword(updateUserDto: UpdateUserDto): Boolean
+    fun login(userRegisterDto: UserRegisterDto): Boolean
+    fun changePassword(userRegisterDto: UserRegisterDto): Boolean
+    fun updateUserProfile(updateUserDto: UpdateUserDto): Boolean
     fun deleteUser(userId: String): Boolean
     fun checkDuplicateId(userId: String): Boolean
 }

--- a/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
@@ -59,7 +59,7 @@ class UserServiceImpl(
             return if (findById.isPresent) {
                 passwordEncoder.matches(userRegisterDto.password, findById.get().password)
             } else {
-                false
+                throw NoneUserException("No User. id = ${userRegisterDto.email}")
             }
         } else {
             throw NotValidUserRegisterFormException("Not Valid UserRegisterForm : ${userRegisterDto}" ,userRegisterDto)

--- a/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
@@ -5,6 +5,7 @@ import com.example.be.dto.UserDto
 import com.example.be.dto.UserRegisterDto
 import com.example.be.entity.UserRegisterInfo
 import com.example.be.exception.NoneUserException
+import com.example.be.exception.NotValidUserRegisterFormException
 import com.example.be.repository.UserRepository
 import com.example.be.repository.UserRegisterRepository
 import lombok.RequiredArgsConstructor
@@ -21,6 +22,7 @@ class UserServiceImpl(
 
     companion object {
         private const val MAX_ID_LENGTH = 15
+        private const val MIN_ID_LENGTH = 5
         private const val MAX_PASSWORD_LENGTH = 20
         private const val MIN_PASSWORD_LENGTH = 8
     }
@@ -45,12 +47,13 @@ class UserServiceImpl(
             userRegisterRepository.save(userRegisterInfoData)
             true
         } else {
-            false
+            throw NotValidUserRegisterFormException("Not Valid UserRegisterForm : ${userRegisterDto}" ,userRegisterDto)
         }
     }
 
     @Transactional(readOnly = true)
     override fun login(userRegisterDto: UserRegisterDto): Boolean {
+
         val findById = userRegisterRepository.findById(userRegisterDto.email)
 
         return if (findById.isPresent) {
@@ -69,7 +72,7 @@ class UserServiceImpl(
             userRegisterRepository.save(user)
             true
         } else {
-            false
+            throw NotValidUserRegisterFormException("Not Valid UserRegisterForm : ${userRegisterDto}" ,userRegisterDto)
         }
     }
 
@@ -77,10 +80,10 @@ class UserServiceImpl(
         TODO("Not yet implemented")
     }
 
-    override fun deleteUser(userEmail: String): Boolean {
-        return if (userRepository.findByEmail(userEmail) != null && userRegisterRepository.findById(userEmail).isPresent) {
-            userRegisterRepository.deleteById(userEmail)
-            userRepository.deleteUserByEmail(userEmail)
+    override fun deleteUser(userRegisterDto: UserRegisterDto): Boolean {
+        return if (userRepository.findByEmail(userRegisterDto.email) != null && userRegisterRepository.findById(userRegisterDto.email).isPresent) {
+            userRegisterRepository.deleteById(userRegisterDto.email)
+            userRepository.deleteUserByEmail(userRegisterDto.email)
             true
         } else {
             false
@@ -95,6 +98,7 @@ class UserServiceImpl(
         val lastIndexOf: Int = userRegisterDto.email.lastIndexOf('@')
         val id = userRegisterDto.email.substring(0, lastIndexOf)
 
-        return id.length <= MAX_ID_LENGTH && (userRegisterDto.password.length in MIN_PASSWORD_LENGTH..MAX_PASSWORD_LENGTH)
+        return (id.length in MIN_ID_LENGTH .. MAX_ID_LENGTH) &&
+                (userRegisterDto.password.length in MIN_PASSWORD_LENGTH..MAX_PASSWORD_LENGTH)
     }
 }

--- a/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
@@ -77,12 +77,18 @@ class UserServiceImpl(
         TODO("Not yet implemented")
     }
 
-    override fun deleteUser(userId: String): Boolean {
-        TODO("Not yet implemented")
+    override fun deleteUser(userEmail: String): Boolean {
+        return if (userRepository.findByEmail(userEmail) != null && userRegisterRepository.findById(userEmail).isPresent) {
+            userRegisterRepository.deleteById(userEmail)
+            userRepository.deleteUserByEmail(userEmail)
+            true
+        } else {
+            false
+        }
     }
 
-    override fun checkDuplicateId(userId: String): Boolean {
-        return userRegisterRepository.findById(userId).isPresent
+    override fun checkDuplicateId(userEmail: String): Boolean {
+        return userRegisterRepository.findById(userEmail).isPresent
     }
 
     private fun checkValid(userRegisterDto: UserRegisterDto): Boolean {

--- a/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
@@ -1,0 +1,80 @@
+package com.example.be.service
+
+import com.example.be.dto.UpdateUserDto
+import com.example.be.dto.UserDto
+import com.example.be.dto.UserRegisterDto
+import com.example.be.entity.UserRegisterInfo
+import com.example.be.exception.NoneUserException
+import com.example.be.repository.UserRepository
+import com.example.be.repository.UserRegisterRepository
+import lombok.RequiredArgsConstructor
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@RequiredArgsConstructor
+class UserServiceImpl(
+    val userRepository: UserRepository,
+    val userRegisterRepository: UserRegisterRepository,
+    val passwordEncoder: PasswordEncoder): UserService {
+
+    companion object {
+        private const val MAX_ID_LENGTH = 15
+        private const val MAX_PASSWORD_LENGTH = 20
+    }
+
+    @Transactional(readOnly = true)
+    override fun getUserProfile(userId: String): UserDto {
+        val findById = userRepository.findById(userId)
+        if (findById.isPresent) {
+            return findById.get().toDataModel()
+        } else {
+            throw NoneUserException("No User. id = ${userId}")
+        }
+    }
+
+    @Transactional
+    override fun register(userRegisterDto: UserRegisterDto): Boolean {
+        return if (checkValid(userRegisterDto)) {
+            val userRegisterInfoData = UserRegisterInfo(
+                id = userRegisterDto.email,
+                password = passwordEncoder.encode(userRegisterDto.password)
+            )
+            userRegisterRepository.save(userRegisterInfoData)
+            true
+        } else {
+            false
+        }
+    }
+
+    @Transactional(readOnly = true)
+    override fun login(userId: String, password: String): Boolean {
+        val findById = userRegisterRepository.findById(userId)
+
+        return if (findById.isPresent) {
+            passwordEncoder.matches(password, findById.get().password)
+        } else {
+            false
+        }
+    }
+
+    override fun changePassword(updateUserDto: UpdateUserDto): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteUser(userId: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkDuplicateId(userId: String): Boolean {
+        return userRegisterRepository.findById(userId).isPresent
+    }
+
+    private fun checkValid(userRegisterDto: UserRegisterDto): Boolean {
+        val lastIndexOf: Int = userRegisterDto.email.lastIndexOf('@')
+        val id = userRegisterDto.email.substring(0, lastIndexOf)
+
+        return id.length <= MAX_ID_LENGTH && userRegisterDto.password.length <= MAX_PASSWORD_LENGTH
+    }
+}

--- a/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
@@ -22,6 +22,7 @@ class UserServiceImpl(
     companion object {
         private const val MAX_ID_LENGTH = 15
         private const val MAX_PASSWORD_LENGTH = 20
+        private const val MIN_PASSWORD_LENGTH = 8
     }
 
     @Transactional(readOnly = true)
@@ -60,7 +61,16 @@ class UserServiceImpl(
     }
 
     override fun changePassword(userRegisterDto: UserRegisterDto): Boolean {
-        TODO("Not yet implemented")
+        return if (checkValid(userRegisterDto)) {
+            val user = UserRegisterInfo(
+                id = userRegisterDto.email,
+                password = passwordEncoder.encode(userRegisterDto.password)
+            )
+            userRegisterRepository.save(user)
+            true
+        } else {
+            false
+        }
     }
 
     override fun updateUserProfile(updateUserDto: UpdateUserDto): Boolean {
@@ -79,6 +89,6 @@ class UserServiceImpl(
         val lastIndexOf: Int = userRegisterDto.email.lastIndexOf('@')
         val id = userRegisterDto.email.substring(0, lastIndexOf)
 
-        return id.length <= MAX_ID_LENGTH && userRegisterDto.password.length <= MAX_PASSWORD_LENGTH
+        return id.length <= MAX_ID_LENGTH && (userRegisterDto.password.length in MIN_PASSWORD_LENGTH..MAX_PASSWORD_LENGTH)
     }
 }

--- a/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/be/service/UserServiceImpl.kt
@@ -49,17 +49,21 @@ class UserServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun login(userId: String, password: String): Boolean {
-        val findById = userRegisterRepository.findById(userId)
+    override fun login(userRegisterDto: UserRegisterDto): Boolean {
+        val findById = userRegisterRepository.findById(userRegisterDto.email)
 
         return if (findById.isPresent) {
-            passwordEncoder.matches(password, findById.get().password)
+            passwordEncoder.matches(userRegisterDto.password, findById.get().password)
         } else {
             false
         }
     }
 
-    override fun changePassword(updateUserDto: UpdateUserDto): Boolean {
+    override fun changePassword(userRegisterDto: UserRegisterDto): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateUserProfile(updateUserDto: UpdateUserDto): Boolean {
         TODO("Not yet implemented")
     }
 

--- a/src/test/kotlin/com/example/be/Fixture.kt
+++ b/src/test/kotlin/com/example/be/Fixture.kt
@@ -1,8 +1,10 @@
 package com.example.be
 
 import com.example.be.dto.*
-import com.example.be.entity.*
-import org.springframework.security.crypto.password.PasswordEncoder
+import com.example.be.entity.Board
+import com.example.be.entity.Comment
+import com.example.be.entity.Content
+import com.example.be.entity.User
 import java.time.LocalDateTime
 import java.util.*
 
@@ -122,7 +124,7 @@ class Fixture {
         )
 
         val userRegisterDto = UserRegisterDto(
-            email = "test@naver.com",
+            email = "test123@naver.com",
             password = "test12345"
         )
 

--- a/src/test/kotlin/com/example/be/Fixture.kt
+++ b/src/test/kotlin/com/example/be/Fixture.kt
@@ -123,7 +123,7 @@ class Fixture {
 
         val userRegisterDto = UserRegisterDto(
             email = "test@naver.com",
-            password = "test123"
+            password = "test12345"
         )
 
         val updateUserDto = UpdateUserDto(

--- a/src/test/kotlin/com/example/be/Fixture.kt
+++ b/src/test/kotlin/com/example/be/Fixture.kt
@@ -1,9 +1,8 @@
 package com.example.be
 
 import com.example.be.dto.*
-import com.example.be.entity.Board
-import com.example.be.entity.Comment
-import com.example.be.entity.Content
+import com.example.be.entity.*
+import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.*
 
@@ -106,6 +105,20 @@ class Fixture {
             followers = Collections.singletonList("testId2"),
             followings = Collections.emptyList(),
             tags = Collections.singletonList("여행")
+        )
+
+        val user = User(
+            id = userDto.id,
+            email = userDto.email,
+            name = userDto.name,
+            nickName = userDto.nickName,
+            intro = userDto.intro,
+            profileImage = userDto.profileImage,
+            scraps = userDto.scraps,
+            likes = userDto.likes,
+            followers = userDto.followers,
+            followings = userDto.followings,
+            tags = userDto.tags
         )
 
         val userRegisterDto = UserRegisterDto(

--- a/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
+++ b/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
@@ -5,7 +5,6 @@ import com.example.be.SpringMockMvcTestSupport
 import com.example.be.exception.NoneUserException
 import com.example.be.service.UserService
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -194,7 +193,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val updateUserDto = Fixture.updateUserDto
 
                 // when
-                Mockito.`when`(userService.updateUserProfile(updateUserDto)).thenReturn(true)
+                Mockito.`when`(userService.changePassword(updateUserDto)).thenReturn(true)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.put(inputUri)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -216,7 +215,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val updateUserDto = Fixture.updateUserDto
 
                 // when
-                Mockito.`when`(userService.updateUserProfile(updateUserDto)).thenReturn(false)
+                Mockito.`when`(userService.changePassword(updateUserDto)).thenReturn(false)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.put(inputUri)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
+++ b/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
@@ -134,8 +134,8 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
 
             @ParameterizedTest
             @CsvSource(
-                "test",
-                "wrongwrongwrong1"
+                "test@naver.com",
+                "wrongwrongwrong1@daum.com"
             )
             @DisplayName("id의 길이가 ${UserServiceImpl.MIN_ID_LENGTH}미만이거나 ${UserServiceImpl.MAX_ID_LENGTH}초과이면, NotValidUserRegisterFormException를 담은 400를 반환한다.")
             fun test02(inputVal: String) {

--- a/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
+++ b/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
@@ -5,6 +5,7 @@ import com.example.be.SpringMockMvcTestSupport
 import com.example.be.exception.NoneUserException
 import com.example.be.service.UserService
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.nhaarman.mockitokotlin2.any
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -83,15 +84,15 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
             @DisplayName("id, password에 대응되는 user가 있다면, true와 200을 반환한다.")
             fun test00() {
                 // given
-                val inputUri: String = "/user/login"
-                val userId = Fixture.userRegisterDto.email
+                val inputUri = "/user/login"
+                val email = Fixture.userRegisterDto.email
                 val password = Fixture.userRegisterDto.password
 
                 // when
-                Mockito.`when`(userService.login(userId, password)).thenReturn(true)
+                Mockito.`when`(userService.login(any())).thenReturn(true)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.get(inputUri)
-                        .param("userId", userId)
+                        .param("email", email)
                         .param("password", password)
                 )
 
@@ -111,10 +112,10 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val password = "wrong password"
 
                 // when
-                Mockito.`when`(userService.login(userId, password)).thenReturn(false)
+                Mockito.`when`(userService.login(any())).thenReturn(false)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.get(inputUri)
-                        .param("userId", userId)
+                        .param("email", userId)
                         .param("password", password)
                 )
 
@@ -193,7 +194,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val updateUserDto = Fixture.updateUserDto
 
                 // when
-                Mockito.`when`(userService.changePassword(updateUserDto)).thenReturn(true)
+                Mockito.`when`(userService.updateUserProfile(updateUserDto)).thenReturn(true)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.put(inputUri)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -215,7 +216,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val updateUserDto = Fixture.updateUserDto
 
                 // when
-                Mockito.`when`(userService.changePassword(updateUserDto)).thenReturn(false)
+                Mockito.`when`(userService.updateUserProfile(updateUserDto)).thenReturn(false)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.put(inputUri)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
+++ b/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
@@ -244,13 +244,14 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
             fun test00() {
                 // given
                 val inputUri: String = "/user"
-                val userId = Fixture.userDto.id
+                val user = Fixture.userRegisterDto
 
                 // when
-                Mockito.`when`(userService.deleteUser(userId)).thenReturn(true)
+                Mockito.`when`(userService.deleteUser(any())).thenReturn(true)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.delete(inputUri)
-                        .param("userId", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(user))
                 )
 
                 // then
@@ -265,13 +266,14 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
             fun test01() {
                 // given
                 val inputUri: String = "/user"
-                val userId = Fixture.userDto.id
+                val user = Fixture.userRegisterDto
 
                 // when
-                Mockito.`when`(userService.deleteUser(userId)).thenReturn(false)
+                Mockito.`when`(userService.deleteUser(any())).thenReturn(false)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.delete(inputUri)
-                        .param("userId", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(user))
                 )
 
                 // then

--- a/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
+++ b/src/test/kotlin/com/example/be/controller/UserRegisterInfoControllerTest.kt
@@ -42,7 +42,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val inputId = Fixture.userDto.id
 
                 // when
-                Mockito.`when`(userService.getUserProfile(inputId)).thenReturn(Fixture.userDto)
+                Mockito.`when`(userService.getUserProfile(Mockito.anyString())).thenReturn(Fixture.userDto)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.get(inputUri)
                         .param("userId", inputId)
@@ -63,7 +63,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val inputId = "None"
 
                 // when
-                Mockito.`when`(userService.getUserProfile(inputId)).thenThrow(NoneUserException("No User. id = ${inputId}"))
+                Mockito.`when`(userService.getUserProfile(Mockito.anyString())).thenThrow(NoneUserException("No User. id = ${inputId}"))
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.get(inputUri)
                         .param("userId", inputId)
@@ -142,7 +142,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val inputUri: String = "/user"
 
                 // when
-                Mockito.`when`(userService.register(Fixture.userRegisterDto)).thenReturn(true)
+                Mockito.`when`(userService.register(any())).thenReturn(true)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.post(inputUri)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -163,7 +163,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val inputUri = "/user"
 
                 // when
-                Mockito.`when`(userService.register(Fixture.userRegisterDto)).thenReturn(false)
+                Mockito.`when`(userService.register(any())).thenReturn(false)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.post(inputUri)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -194,7 +194,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val updateUserDto = Fixture.updateUserDto
 
                 // when
-                Mockito.`when`(userService.updateUserProfile(updateUserDto)).thenReturn(true)
+                Mockito.`when`(userService.updateUserProfile(any())).thenReturn(true)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.put(inputUri)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -216,7 +216,7 @@ internal class UserRegisterInfoControllerTest : SpringMockMvcTestSupport() {
                 val updateUserDto = Fixture.updateUserDto
 
                 // when
-                Mockito.`when`(userService.updateUserProfile(updateUserDto)).thenReturn(false)
+                Mockito.`when`(userService.updateUserProfile(any())).thenReturn(false)
                 val actions = mockMvc.perform(
                     MockMvcRequestBuilders.put(inputUri)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
@@ -4,6 +4,7 @@ import com.example.be.Fixture
 import com.example.be.dto.UserRegisterDto
 import com.example.be.entity.UserRegisterInfo
 import com.example.be.exception.NoneUserException
+import com.example.be.exception.NotValidUserRegisterFormException
 import com.example.be.repository.UserRegisterRepository
 import com.example.be.repository.UserRepository
 import com.nhaarman.mockitokotlin2.any
@@ -96,22 +97,44 @@ internal class UserServiceImplTest {
 
         @ParameterizedTest
         @CsvSource(
-            "12345abcdefghijklmnop@naver.com, test123",
-            "test@naver.com, wrongpassword0123456789",
-            "test@naver.com, 1234567"
+            "test@naver.com",
+            "wrongwrongwrong1@daum.com"
         )
-        @DisplayName("email혹은 비밀번호의 검증에 실패하면, false를 반환한다.")
-        fun test01(inputEmail: String, inputPassword: String) {
+        @DisplayName("id의 길이가 ${UserServiceImpl.MIN_ID_LENGTH}미만이거나 ${UserServiceImpl.MAX_ID_LENGTH}초과이면, NotValidUserRegisterFormException를 던진다.")
+        fun test01(inputEmail: String) {
             // given
             val userRegisterDto = UserRegisterDto(
                 email = inputEmail,
+                password = "inputPassword"
+            )
+
+            // when
+            // then
+            val exception = assertThrows(NotValidUserRegisterFormException::class.java) {
+                service.register(userRegisterDto)
+            }
+            println(exception)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "wrong12",
+            "wrongwrongwrongwrong1"
+        )
+        @DisplayName("password의 길이가 ${UserServiceImpl.MIN_PASSWORD_LENGTH}미만이거나 ${UserServiceImpl.MAX_PASSWORD_LENGTH}초과이면, NotValidUserRegisterFormException를 던진다.")
+        fun test02(inputPassword: String) {
+            // given
+            val userRegisterDto = UserRegisterDto(
+                email = "test123@naver.com",
                 password = inputPassword
             )
 
             // when
             // then
-            val result: Boolean = service.register(userRegisterDto)
-            assertFalse(result)
+            val exception = assertThrows(NotValidUserRegisterFormException::class.java) {
+                service.register(userRegisterDto)
+            }
+            println(exception)
         }
     }
 
@@ -202,7 +225,7 @@ internal class UserServiceImplTest {
             "12345",
             "asdfg12345asdfb1234567"
         )
-        @DisplayName("비밀번호의 길이가 8 이상 20 이하가 아니라면, false를 반환한다.")
+        @DisplayName("비밀번호의 길이가 ${UserServiceImpl.MIN_PASSWORD_LENGTH}미만 ${UserServiceImpl.MAX_PASSWORD_LENGTH}초과라면, NotValidUserRegisterFormException를 던진다.")
         fun test01(inputPassword: String) {
             // given
             val userRegisterDto = UserRegisterDto(
@@ -212,8 +235,10 @@ internal class UserServiceImplTest {
 
             // when
             // then
-            val result = service.changePassword(userRegisterDto)
-            assertFalse(result)
+            val exception = assertThrows(NotValidUserRegisterFormException::class.java) {
+                service.changePassword(userRegisterDto)
+            }
+            println(exception)
         }
     }
 

--- a/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
@@ -180,7 +180,7 @@ internal class UserServiceImplTest {
         }
 
         @Test
-        @DisplayName("id가 틀리면, false를 반환한다.")
+        @DisplayName("id가 db에 존재하지 않으면, NoneUserException를 던진다.")
         fun test02() {
             // given
             val userRegisterDto = Fixture.userRegisterDto
@@ -189,8 +189,10 @@ internal class UserServiceImplTest {
             Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.empty())
 
             // then
-            val result = service.login(userRegisterDto)
-            assertFalse(result)
+            val exception = assertThrows(NoneUserException::class.java) {
+                service.login(userRegisterDto)
+            }
+            println(exception)
         }
     }
 

--- a/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
@@ -130,7 +130,7 @@ internal class UserServiceImplTest {
             // when
             Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.of(userRegisterInfo))
             Mockito.`when`(passwordEncoder.matches(Mockito.anyString(), Mockito.anyString())).thenReturn(true)
-            val result = service.login(userRegisterDto.email, userRegisterDto.password)
+            val result = service.login(userRegisterDto)
 
             // then
             assertTrue(result)
@@ -151,7 +151,7 @@ internal class UserServiceImplTest {
             Mockito.`when`(passwordEncoder.matches(Mockito.anyString(), Mockito.anyString())).thenReturn(false)
 
             // then
-            val result = service.login(userRegisterDto.email, userRegisterDto.password)
+            val result = service.login(userRegisterDto)
             assertFalse(result)
         }
 
@@ -165,7 +165,7 @@ internal class UserServiceImplTest {
             Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.empty())
 
             // then
-            val result = service.login(userRegisterDto.email, userRegisterDto.password)
+            val result = service.login(userRegisterDto)
             assertFalse(result)
         }
 

--- a/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
@@ -1,0 +1,174 @@
+package com.example.be.service
+
+import com.example.be.Fixture
+import com.example.be.dto.UserRegisterDto
+import com.example.be.entity.UserRegisterInfo
+import com.example.be.exception.NoneUserException
+import com.example.be.repository.UserRegisterRepository
+import com.example.be.repository.UserRepository
+import com.nhaarman.mockitokotlin2.any
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.util.*
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest
+internal class UserServiceImplTest {
+
+    @InjectMocks
+    lateinit var service: UserServiceImpl
+
+    @Mock
+    lateinit var userRepository: UserRepository
+
+    @Mock
+    lateinit var userRegisterRepository: UserRegisterRepository
+
+    @Mock
+    lateinit var passwordEncoder: PasswordEncoder
+
+    @Nested
+    @DisplayName("User의 정보를 가져올 때,")
+    inner class GetProfileUserRegisterInfoTest {
+        @Test
+        @DisplayName("userId에 대응되는 User를 UserDto로 반환한다.")
+        fun test00() {
+            // given
+            val userId = Fixture.userDto.id
+            val user = Fixture.user
+
+            // when
+            Mockito.`when`(userRepository.findById(userId)).thenReturn(Optional.of(user))
+            val userDto = service.getUserProfile(userId)
+
+            // then
+            Assertions.assertThat(userDto).usingRecursiveComparison().isEqualTo(user.toDataModel())
+        }
+
+        @Test
+        @DisplayName("userId에 대응되는 User가 없는 경우, NoneUserException을 던진다.")
+        fun test01() {
+            // given
+            val userId = "None"
+
+            // when
+            Mockito.`when`(userRepository.findById(userId)).thenReturn(Optional.empty())
+
+            // then
+            assertThrows(NoneUserException::class.java) { service.getUserProfile(userId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("User를 등록할 때,")
+    inner class RegisterTest {
+        @Test
+        @DisplayName("user등록에 성공하면, true를 반환한다.")
+        fun test00() {
+            // given
+            val userRegisterDto = Fixture.userRegisterDto
+            val userRegisterInfo = UserRegisterInfo(
+                id = userRegisterDto.email,
+                password = "encoded password"
+            )
+
+            // when
+            Mockito.`when`(passwordEncoder.encode(Mockito.anyString())).thenReturn("encoded password")
+            Mockito.`when`(userRegisterRepository.save(any())).thenReturn(userRegisterInfo)
+            val result = service.register(userRegisterDto)
+
+            // then
+            assertTrue(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "12345abcdefghijklmnop@naver.com, test123",
+            "test@naver.com, wrongpassword0123456789"
+        )
+        @DisplayName("email혹은 비밀번호의 검증에 실패하면, false를 반환한다.")
+        fun test01(inputEmail: String, inputPassword: String) {
+            // given
+            val userRegisterDto = UserRegisterDto(
+                email = inputEmail,
+                password = inputPassword
+            )
+
+            // when
+            // then
+            val result: Boolean = service.register(userRegisterDto)
+            assertFalse(result)
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 할 때,")
+    inner class LoginTest {
+        @Test
+        @DisplayName("성공하면, true를 반환한다.")
+        fun test00() {
+            // given
+            val userRegisterDto = Fixture.userRegisterDto
+            val userRegisterInfo = UserRegisterInfo(
+                id = userRegisterDto.email,
+                password = "encoded password"
+            )
+
+            // when
+            Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.of(userRegisterInfo))
+            Mockito.`when`(passwordEncoder.matches(Mockito.anyString(), Mockito.anyString())).thenReturn(true)
+            val result = service.login(userRegisterDto.email, userRegisterDto.password)
+
+            // then
+            assertTrue(result)
+        }
+
+        @Test
+        @DisplayName("비밀번호가 틀리면, false를 반환한다.")
+        fun test01() {
+            // given
+            val userRegisterDto = Fixture.userRegisterDto
+            val userRegisterInfo = UserRegisterInfo(
+                id = userRegisterDto.email,
+                password = "encoded password"
+            )
+
+            // when
+            Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.of(userRegisterInfo))
+            Mockito.`when`(passwordEncoder.matches(Mockito.anyString(), Mockito.anyString())).thenReturn(false)
+
+            // then
+            val result = service.login(userRegisterDto.email, userRegisterDto.password)
+            assertFalse(result)
+        }
+
+        @Test
+        @DisplayName("id가 틀리면, false를 반환한다.")
+        fun test02() {
+            // given
+            val userRegisterDto = Fixture.userRegisterDto
+
+            // when
+            Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.empty())
+
+            // then
+            val result = service.login(userRegisterDto.email, userRegisterDto.password)
+            assertFalse(result)
+        }
+
+    }
+
+}

--- a/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -224,10 +223,10 @@ internal class UserServiceImplTest {
         @DisplayName("성공하면, true를 반환한다.")
         fun test00() {
             // given
-            val userEmail = Fixture.userRegisterDto.email
+            val user = Fixture.userRegisterDto
             val userRegisterInfo = UserRegisterInfo(
-                id = Fixture.userRegisterDto.email,
-                password = "!@#$%"
+                id = user.email,
+                password = user.password
             )
 
             // when
@@ -237,7 +236,7 @@ internal class UserServiceImplTest {
             Mockito.doNothing().`when`(userRepository).deleteUserByEmail(Mockito.anyString())
 
             // then
-            val result = service.deleteUser(userEmail)
+            val result = service.deleteUser(user)
             assertTrue(result)
         }
 
@@ -245,14 +244,14 @@ internal class UserServiceImplTest {
         @DisplayName("실패하면, false를 반환한다.")
         fun test01() {
             // given
-            val userEmail = Fixture.userRegisterDto.email
+            val user = Fixture.userRegisterDto
 
             // when
             Mockito.`when`(userRepository.findByEmail(Mockito.anyString())).thenReturn(null)
             Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.empty())
 
             // then
-            val result = service.deleteUser(userEmail)
+            val result = service.deleteUser(user)
             assertFalse(result)
         }
     }

--- a/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
@@ -216,4 +216,45 @@ internal class UserServiceImplTest {
             assertFalse(result)
         }
     }
+
+    @Nested
+    @DisplayName("회원탈퇴를 할 때,")
+    inner class DeleteUserTest {
+        @Test
+        @DisplayName("성공하면, true를 반환한다.")
+        fun test00() {
+            // given
+            val userEmail = Fixture.userRegisterDto.email
+            val userRegisterInfo = UserRegisterInfo(
+                id = Fixture.userRegisterDto.email,
+                password = "!@#$%"
+            )
+
+            // when
+            Mockito.`when`(userRepository.findByEmail(Mockito.anyString())).thenReturn(Fixture.user)
+            Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.of(userRegisterInfo))
+            Mockito.doNothing().`when`(userRegisterRepository).deleteById(Mockito.anyString())
+            Mockito.doNothing().`when`(userRepository).deleteUserByEmail(Mockito.anyString())
+
+            // then
+            val result = service.deleteUser(userEmail)
+            assertTrue(result)
+        }
+
+        @Test
+        @DisplayName("실패하면, false를 반환한다.")
+        fun test01() {
+            // given
+            val userEmail = Fixture.userRegisterDto.email
+
+            // when
+            Mockito.`when`(userRepository.findByEmail(Mockito.anyString())).thenReturn(null)
+            Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.empty())
+
+            // then
+            val result = service.deleteUser(userEmail)
+            assertFalse(result)
+        }
+    }
+
 }

--- a/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/example/be/service/UserServiceImplTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -241,18 +242,19 @@ internal class UserServiceImplTest {
         }
 
         @Test
-        @DisplayName("실패하면, false를 반환한다.")
-        fun test01() {
+        @DisplayName("DB에 삭제할 id가 존재하지 않으면, NoneUserException를 던진다.")
+        fun test02() {
             // given
             val user = Fixture.userRegisterDto
 
             // when
-            Mockito.`when`(userRepository.findByEmail(Mockito.anyString())).thenReturn(null)
             Mockito.`when`(userRegisterRepository.findById(Mockito.anyString())).thenReturn(Optional.empty())
 
             // then
-            val result = service.deleteUser(user)
-            assertFalse(result)
+            val exception = assertThrows(NoneUserException::class.java) {
+                service.deleteUser(user)
+            }
+            println(exception)
         }
     }
 


### PR DESCRIPTION
- 지난번의 코드와 비교해서 실패케이스인 경우 false를 return -> throw RuntimeException의 방식으로 바꿨습니다.
- UpdateUserProfile과 deleteUser에서 삭제로직은 아직 미완성입니다.
- test 결과 (변경한 로직에 따른 실패케이스 모두 수정완료)
![스크린샷 2022-05-23 오후 5 38 41](https://user-images.githubusercontent.com/46814964/169779213-bf356788-2881-4863-97cf-dc7655910838.png)
![스크린샷 2022-05-23 오후 5 39 08](https://user-images.githubusercontent.com/46814964/169779306-fd899f5b-79d6-4aeb-b9b7-aefc9bd6340f.png)
 